### PR TITLE
Fix a potential buffer overflow error

### DIFF
--- a/ErrorCorrection.cpp
+++ b/ErrorCorrection.cpp
@@ -710,6 +710,9 @@ int ErrorCorrection( char *id, char *seq, char *qual, int pairStrongTrustThresho
 	struct _segmentInfo segmentInfo[MAX_READ_LENGTH], trustedIsland[MAX_READ_LENGTH] ;
 	int segmentInfoCnt = 0, trustedIslandCnt = 0 ;
 
+	if ( strlen( seq ) < kmerLength )
+	  return -1 ;
+	
 	kcode.Restart() ;
 	for ( i = 0 ; i < kmerLength - 1 ; ++i )
 		kcode.Append( seq[i] ) ;
@@ -1485,6 +1488,9 @@ int GetStrongTrustedThreshold( char *seq, char *qual, KmerCode &kcode, Store &km
 	int readLength ;
 	int kmerLength = kcode.GetKmerLength() ;
 
+	if ( strlen( seq ) < kmerLength )
+	  return -1 ;
+	
 	kcode.Restart() ;
 	for ( i = 0 ; i < kmerLength - 1 ; ++i )
 		kcode.Append( seq[i] ) ;


### PR DESCRIPTION
This should fix an edge case, where the program would throw out a buffer overflow exception (or not, instead would read random bytes until it is met with '\0') if the seq length is smaller than the kmer length.

```
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x0000155554fae859 in __GI_abort () at abort.c:79
#2  0x000015555501926e in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x15555514308f "*** %s ***: terminated\n") at ../sysdeps/posix/libc_fatal.c:155
#3  0x00001555550bbaba in __GI___fortify_fail (msg=msg@entry=0x155555143025 "buffer overflow detected") at fortify_fail.c:26
#4  0x00001555550ba356 in __GI___chk_fail () at chk_fail.c:28
#5  0x000055555555a316 in memset (__len=1043, __ch=0, __dest=0x155554b6e640) at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:71
#6  ErrorCorrection (id=<optimized out>, seq=0x55567526a284 "AATGATACGGCGACCACCG", qual=0x55567526a684 'F' <repeats 19 times>, pairStrongTrustThreshold=pairStrongTrustThreshold@entry=1608, 
    kcode=..., kmers=...) at ErrorCorrection.cpp:929
#7  0x000055555555a9a0 in ErrorCorrection_Thread (arg=0x7fffffff5910) at ErrorCorrection.cpp:118
#8  0x00001555554ee609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#9  0x00001555550ab133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```